### PR TITLE
Report success status indicating whether it was a cache hit or not.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 dist: xenial
 sudo: enabled
 os:
-  - osx
+  # - osx
   - linux
 
 env:

--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ val resolver = ArtifactResolver() // creates a resolver with repo list defaultin
 val artifact = resolver.artifactFor("com.google.guava:guava:27.1-jre") // returns Artifact
 val resolvedArtifact = resolver.resolveArtifact(artifact) // returns ResolvedArtifact
 val result = resolver.download(resolvedArtifact) // returns FetchStatus
+
+// if you care about whether it was a cache-hit or not, do this. Otherwise test for "is SUCCESSFUL"
 when (result) {
-  is SUCCESSFUL.FOUND_IN_CACHE -> ""
+  is SUCCESSFUL.FOUND_IN_CACHE -> { /* win! */ }
+  is SUCCESSFUL.SUCESSFULLY_FETCHED -> { /* win, but remotely! */ }
+  else -> { /* Handle error */ }
 }
-if (result is SUCCESSFUL) { /* win! */ }
 ```
 
 ### Adding Repositories

--- a/src/main/java/com/squareup/tools/maven/resolution/AbstractArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/AbstractArtifactFetcher.kt
@@ -71,11 +71,11 @@ abstract class AbstractArtifactFetcher(protected val cacheDir: Path): ArtifactFe
         !fileSpec.localFile.exists -> if (errors.isEmpty()) RepositoryFetchStatus.NOT_FOUND else FetchStatus.ERROR(
             errors)
         !fileSpec.validateHashes() -> FetchStatus.INVALID_HASH
-        else -> RepositoryFetchStatus.SUCCESSFUL
+        else -> RepositoryFetchStatus.SUCCESSFUL.SUCCESSFULLY_FETCHED
       }
     } else {
       info { "Found cached file ${fileSpec.localFile}" }
-      return RepositoryFetchStatus.SUCCESSFUL
+      return RepositoryFetchStatus.SUCCESSFUL.FOUND_IN_CACHE
     }
   }
 

--- a/src/main/java/com/squareup/tools/maven/resolution/AbstractArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/AbstractArtifactFetcher.kt
@@ -16,23 +16,23 @@
 package com.squareup.tools.maven.resolution
 
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus
-import org.apache.maven.model.Repository
-import java.nio.file.CopyOption
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import org.apache.maven.model.Repository
 
 /**
- * A convenience partial implementation which does all the organization around fetch results and trying
- * various repositories.
+ * A convenience partial implementation which does all the organization around fetch results and
+ * trying various repositories.
  */
-abstract class AbstractArtifactFetcher(protected val cacheDir: Path): ArtifactFetcher {
+abstract class AbstractArtifactFetcher(protected val cacheDir: Path) : ArtifactFetcher {
   override fun fetchPom(pom: PomFile, repositories: List<Repository>): FetchStatus =
       fetchFiles(pom, repositories)
 
-  override fun fetchArtifact(artifactFile: ArtifactFile, repositories: List<Repository>): FetchStatus =
-      fetchFiles(artifactFile, repositories)
+  override fun fetchArtifact(
+    artifactFile: ArtifactFile,
+    repositories: List<Repository>
+  ): FetchStatus = fetchFiles(artifactFile, repositories)
 
   /**
    * The workhorse method which actually fetches a file and writes it to the local cacheDir in the
@@ -40,7 +40,11 @@ abstract class AbstractArtifactFetcher(protected val cacheDir: Path): ArtifactFe
    * `"${repository.url}/$path"` to `cacheDir.resolve(path)` for any URLs they support, and return
    * the appropriate RepositoryFetchStatus based on the success of that operation.
    */
-  abstract fun fetchFile(fileSpec: FileSpec, repository: Repository, path: Path): RepositoryFetchStatus
+  abstract fun fetchFile(
+    fileSpec: FileSpec,
+    repository: Repository,
+    path: Path
+  ): RepositoryFetchStatus
 
   fun fetchFiles(fileSpec: FileSpec, repositories: List<Repository>): FetchStatus {
     if (fileSpec.artifact.snapshot)
@@ -68,8 +72,8 @@ abstract class AbstractArtifactFetcher(protected val cacheDir: Path): ArtifactFe
         }
       }
       return when {
-        !fileSpec.localFile.exists -> if (errors.isEmpty()) RepositoryFetchStatus.NOT_FOUND else FetchStatus.ERROR(
-            errors)
+        !fileSpec.localFile.exists ->
+          if (errors.isEmpty()) RepositoryFetchStatus.NOT_FOUND else FetchStatus.ERROR(errors)
         !fileSpec.validateHashes() -> FetchStatus.INVALID_HASH
         else -> RepositoryFetchStatus.SUCCESSFUL.SUCCESSFULLY_FETCHED
       }
@@ -79,7 +83,10 @@ abstract class AbstractArtifactFetcher(protected val cacheDir: Path): ArtifactFe
     }
   }
 
-  private fun fetchFileAndHashes(fileSpec: FileSpec, repository: Repository): RepositoryFetchStatus {
+  private fun fetchFileAndHashes(
+    fileSpec: FileSpec,
+    repository: Repository
+  ): RepositoryFetchStatus {
     // TODO profile and make this a parallel fetch
     val mainFetchResult = fetchFile(fileSpec, repository, fileSpec.path)
 

--- a/src/main/java/com/squareup/tools/maven/resolution/ArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ArtifactFetcher.kt
@@ -18,15 +18,15 @@ package com.squareup.tools.maven.resolution
 import org.apache.maven.model.Repository
 
 sealed class FetchStatus {
-  sealed class RepositoryFetchStatus: FetchStatus() {
+  sealed class RepositoryFetchStatus : FetchStatus() {
     /** Artifact file successfully fetched and validated */
-    sealed class SUCCESSFUL: RepositoryFetchStatus() {
-      object FOUND_IN_CACHE: SUCCESSFUL()
-      object SUCCESSFULLY_FETCHED: SUCCESSFUL()
+    sealed class SUCCESSFUL : RepositoryFetchStatus() {
+      object FOUND_IN_CACHE : SUCCESSFUL()
+      object SUCCESSFULLY_FETCHED : SUCCESSFUL()
     }
 
     /** Artifact file could not be found in any repositories given to the fetcher. */
-    object NOT_FOUND: RepositoryFetchStatus()
+    object NOT_FOUND : RepositoryFetchStatus()
 
     /** An individual error from a given repository (id) */
     data class FETCH_ERROR(
@@ -34,11 +34,11 @@ sealed class FetchStatus {
       val message: Any? = null,
       val responseCode: Int? = null,
       val error: Throwable? = null
-    ): RepositoryFetchStatus()
+    ) : RepositoryFetchStatus()
   }
 
   /** Artifact file found and fetched, but failed hash validation */
-  object INVALID_HASH: FetchStatus()
+  object INVALID_HASH : FetchStatus()
 
   /**
    * A compound error containing the full map of errors from repositories which had errors.
@@ -46,7 +46,7 @@ sealed class FetchStatus {
    * This should be returned where there were non-404 failures from various given repositories,
    * when none of them were successful.
    */
-  data class ERROR(val errors: Map<String, RepositoryFetchStatus>): FetchStatus()
+  data class ERROR(val errors: Map<String, RepositoryFetchStatus>) : FetchStatus()
 }
 
 interface ArtifactFetcher {
@@ -64,4 +64,3 @@ interface ArtifactFetcher {
    */
   fun fetchArtifact(artifactFile: ArtifactFile, repositories: List<Repository>): FetchStatus
 }
-

--- a/src/main/java/com/squareup/tools/maven/resolution/ArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ArtifactFetcher.kt
@@ -20,7 +20,10 @@ import org.apache.maven.model.Repository
 sealed class FetchStatus {
   sealed class RepositoryFetchStatus: FetchStatus() {
     /** Artifact file successfully fetched and validated */
-    object SUCCESSFUL: RepositoryFetchStatus()
+    sealed class SUCCESSFUL: RepositoryFetchStatus() {
+      object FOUND_IN_CACHE: SUCCESSFUL()
+      object SUCCESSFULLY_FETCHED: SUCCESSFUL()
+    }
 
     /** Artifact file could not be found in any repositories given to the fetcher. */
     object NOT_FOUND: RepositoryFetchStatus()

--- a/src/main/java/com/squareup/tools/maven/resolution/ArtifactResolver.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ArtifactResolver.kt
@@ -150,7 +150,7 @@ class ArtifactResolver(
           systemProperties = System.getProperties()
         }
     val builder: ModelBuildingResult = modelBuilder.build(req)
-    return ResolvedArtifact(builder.effectiveModel, cacheDir)
+    return ResolvedArtifact(builder.effectiveModel, cacheDir, fetched is SUCCESSFUL.FOUND_IN_CACHE)
   }
 
   /**

--- a/src/main/java/com/squareup/tools/maven/resolution/ArtifactResolver.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ArtifactResolver.kt
@@ -20,16 +20,16 @@ import com.squareup.tools.maven.resolution.FetchStatus.INVALID_HASH
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.FETCH_ERROR
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.NOT_FOUND
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.SUCCESSFUL
+import java.io.IOException
+import java.lang.IllegalArgumentException
+import java.nio.file.FileSystems
+import java.nio.file.Path
 import org.apache.maven.model.Repository
 import org.apache.maven.model.building.DefaultModelBuilderFactory
 import org.apache.maven.model.building.DefaultModelBuildingRequest
 import org.apache.maven.model.building.ModelBuildingRequest
 import org.apache.maven.model.building.ModelBuildingResult
 import org.apache.maven.model.resolution.ModelResolver
-import java.io.IOException
-import java.lang.IllegalArgumentException
-import java.nio.file.FileSystems
-import java.nio.file.Path
 
 /**
  * The main entry point to the library, which wraps (and mostly hides) the maven resolution
@@ -145,7 +145,7 @@ class ArtifactResolver(
         .apply {
           modelResolver = resolver
           pomFile = artifact.pom.localFile.toFile()
-          setProcessPlugins(false) // Auto-property inference is broken for this property, so use function.
+          setProcessPlugins(false) // Auto-property inference is broken for this property.
           validationLevel = ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL
           systemProperties = System.getProperties()
         }
@@ -169,8 +169,8 @@ class ArtifactResolver(
    * Resolves and downloads the given artifact's pom file and main artifact file.
    *
    * The result is a [Pair<Path, Path] with the first item being the local path to the pom, and
-   * the second being the local path to the artifact file. This version throws an IOException if the
-   * download fails (either for the pom or the artifact), or if the downloaded files fail hash
+   * the second being the local path to the artifact file. This version throws an IOException if
+   * the download fails (either for the pom or the artifact), or if the downloaded files fail hash
    * validation.
    */
   @Throws(IOException::class)
@@ -179,7 +179,8 @@ class ArtifactResolver(
     val resolvedArtifact = resolveArtifact(artifact)
         ?: throw IOException("Could not resolve pom file for $coordinate")
     val status = downloadArtifact(resolvedArtifact)
-    if (status is SUCCESSFUL) return resolvedArtifact.pom.localFile to resolvedArtifact.main.localFile
+    if (status is SUCCESSFUL)
+      return resolvedArtifact.pom.localFile to resolvedArtifact.main.localFile
     else throw IOException("Could not download artifact for $coordinate: $status")
   }
 }

--- a/src/main/java/com/squareup/tools/maven/resolution/HttpArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/HttpArtifactFetcher.kt
@@ -48,8 +48,7 @@ class HttpArtifactFetcher(
     repository: Repository,
     path: Path): RepositoryFetchStatus {
     val url = "${repository.url}/$path"
-    val request: Request = Builder().url(url)
-        .build()
+    val request: Request = Builder().url(url).build()
     return client.newCall(request)
         .also { info { "About to fetch $url" } }
         .execute()
@@ -61,7 +60,7 @@ class HttpArtifactFetcher(
                 try {
                   var localFile = cacheDir.resolve(path)
                   safeWrite(localFile, body)
-                  if (fileSpec.localFile.exists) SUCCESSFUL
+                  if (fileSpec.localFile.exists) SUCCESSFUL.SUCCESSFULLY_FETCHED
                   else FETCH_ERROR(
                       repository = repository.id,
                       message = "File downloaded but did not write successfully."

--- a/src/main/java/com/squareup/tools/maven/resolution/HttpArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/HttpArtifactFetcher.kt
@@ -19,12 +19,12 @@ import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.FETCH_ERROR
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.NOT_FOUND
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.SUCCESSFUL
+import java.io.IOException
+import java.nio.file.Path
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Request.Builder
 import org.apache.maven.model.Repository
-import java.io.IOException
-import java.nio.file.Path
 
 /**
  * An engine for performing fetches against maven repositories.  Generally this class' methods will
@@ -41,12 +41,13 @@ import java.nio.file.Path
 class HttpArtifactFetcher(
   cacheDir: Path,
   private val client: OkHttpClient = OkHttpClient()
-): AbstractArtifactFetcher(cacheDir) {
+) : AbstractArtifactFetcher(cacheDir) {
 
   override fun fetchFile(
     fileSpec: FileSpec,
     repository: Repository,
-    path: Path): RepositoryFetchStatus {
+    path: Path
+  ) : RepositoryFetchStatus {
     val url = "${repository.url}/$path"
     val request: Request = Builder().url(url).build()
     return client.newCall(request)

--- a/src/main/java/com/squareup/tools/maven/resolution/Model.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/Model.kt
@@ -50,8 +50,7 @@ class ResolvedArtifact(
   cacheDir: Path,
   /** Whether this artifact metadata was remotely fetched or satisfied from the local cache. */
   val cached: Boolean = false
-) :
-    Artifact(model.groupId, model.artifactId, model.version, cacheDir) {
+) : Artifact(model.groupId, model.artifactId, model.version, cacheDir) {
   val main = ArtifactFile(this, cacheDir)
 
   val suffix = packagingToSuffix.getOrDefault(model.packaging, model.packaging)

--- a/src/main/java/com/squareup/tools/maven/resolution/Model.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/Model.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.tools.maven.resolution
 
-import org.apache.maven.model.Model
 import java.nio.file.Path
+import org.apache.maven.model.Model
 
 private val packagingToSuffix = mapOf(
     "bundle" to "jar"
@@ -50,7 +50,7 @@ class ResolvedArtifact(
   cacheDir: Path,
   /** Whether this artifact metadata was remotely fetched or satisfied from the local cache. */
   val cached: Boolean = false
-):
+) :
     Artifact(model.groupId, model.artifactId, model.version, cacheDir) {
   val main = ArtifactFile(this, cacheDir)
 
@@ -82,7 +82,9 @@ interface FileSpec {
   val artifact: Artifact
 
   fun validateHashes(): Boolean {
-    assert(localFile.exists) { "Attempted to validate hashes on an un-fetched pom file $localFile." }
+    assert(localFile.exists) {
+      "Attempted to validate hashes on an un-fetched pom file $localFile."
+    }
     return validateHash(localFile, "sha1", localFile.sha1File, Path::sha1) &&
         validateHash(localFile, "md5", localFile.md5File, Path::md5)
   }
@@ -108,7 +110,7 @@ class PomFile
 class ArtifactFile(
   override val artifact: ResolvedArtifact,
   private val cacheDir: Path
-): FileSpec {
+) : FileSpec {
   override val coordinate: String get() = artifact.coordinate
 
   override val path: Path by lazy {

--- a/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
@@ -16,20 +16,19 @@
 package com.squareup.tools.maven.resolution
 
 import com.google.common.truth.Truth.assertThat
-
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.NOT_FOUND
 import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.SUCCESSFUL
-import org.apache.maven.model.Repository
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
 import java.util.concurrent.atomic.AtomicInteger
+import org.apache.maven.model.Repository
 
 internal class FakeFetcher(
-    cacheDir: Path,
-    val repositoriesContent: Map<String, Map<String, String>> = mapOf()
-): AbstractArtifactFetcher(cacheDir) {
+  cacheDir: Path,
+  val repositoriesContent: Map<String, Map<String, String>> = mapOf()
+) : AbstractArtifactFetcher(cacheDir) {
   private val callCounter = AtomicInteger()
   public val count get() = callCounter.get()
   override fun fetchFile(

--- a/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
@@ -47,7 +47,7 @@ internal class FakeFetcher(
     Files.createDirectories(localFile.parent)
     Files.write(localFile, fileContent.toByteArray())
     assertThat(localFile.readText() == fileContent)
-    return SUCCESSFUL
+    return SUCCESSFUL.FOUND_IN_CACHE
   }
 }
 


### PR DESCRIPTION
Make fetch status a bit more subtle, adding status for success by cache hit, and success by successful fetch.

> Note: This is a breaking change for anyone using `foo == SUCCESSFUL`. Prefer `foo is SUCCESSFUL` which is the intended check, and is safe for this change.

Also update the readme a bit.