### PR TITLE
Support maven version comparisons. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ instance) like so:
 ```kotlin
 val resolver = ArtifactResolver(cacheDir = fs.getPath("/some/cache/dir"))
 ```
+
+### Comparing Versions
+
+maven-archeologist has a convenience for representing maven versions in a way that they can be
+compared according to semantic versioning, or at least the maven 3 variant, rather than merely
+lexically.
+
+```kotlin
+val versions = listOf(
+  MavenVersion.from("2.3.5-SNAPSHOT"),
+  MavenVersion.from("2.3.5"),
+  MavenVersion.from("2.0"),
+  MavenVersion.from("2a.0"),
+  MavenVersion.from("2.0-beta"),
+  MavenVersion.from("2.0-beta-SNAPSHOT"),
+  MavenVersion.from("2.3.5.2"),
+).sorted()
+
+println(versions)
+// should print [2.0-beta-SNAPSHOT, 2.0-beta, 2.0, 2.3.5-SAPSHOT, 2.3.5, 2.3.5.2, 2a.0]
+```
+
+> Note: 2a.0 comes after 2.0 because 2a is non-numeric and so is lexically compared.
+
 ## Demo CLI
 
 The project also contains a demo CLI app which will resolve and download the maven artifacts listed

--- a/src/main/java/com/squareup/tools/maven/resolution/MavenVersion.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/MavenVersion.kt
@@ -29,11 +29,11 @@ class MavenVersion private constructor(
   private val raw: String,
   private val elements: List<String>,
   val snapshot: Boolean = false
-): Comparable<MavenVersion>{
+) : Comparable<MavenVersion> {
   override fun toString() = raw
   override fun equals(other: Any?) = other is MavenVersion && compareTo(other) == EQUAL
   override fun hashCode() = 31 + raw.hashCode()
-  override fun compareTo(other: MavenVersion) : Int {
+  override fun compareTo(other: MavenVersion): Int {
     if (raw == other.raw) return EQUAL // simple obvious case.
     // loop through the next-to-last of the shortest.
     val minLength = min(elements.size, other.elements.size)
@@ -110,7 +110,7 @@ internal data class VersionElement(
   }
 }
 
-internal fun String.numberComparison(other: String) : Int? {
+internal fun String.numberComparison(other: String): Int? {
   val a = this.toIntOrNull()
   val b = other.toIntOrNull()
   return if (a != null && b != null) a.compareTo(b)
@@ -119,5 +119,3 @@ internal fun String.numberComparison(other: String) : Int? {
 
 internal fun String.numberOrStringComparison(other: String) =
     numberComparison(other) ?: this.compareTo(other)
-
-

--- a/src/main/java/com/squareup/tools/maven/resolution/MavenVersion.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/MavenVersion.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution
+
+import kotlin.math.min
+
+const val LESS_THAN = -1
+const val GREATER_THAN = 1
+const val EQUAL = 0
+
+/**
+ * Encapsulates the logic of maven version comparisons, notably enshrining the logic described
+ * [in this article](https://blog.soebes.de/blog/2017/02/04/apache-maven-how-version-comparison-works).
+ */
+class MavenVersion private constructor(
+  val raw: String,
+  val elements: List<String>,
+  val snapshot: Boolean = false
+): Comparable<MavenVersion>{
+  override fun toString() = raw
+  override fun equals(other: Any?) = other is MavenVersion && compareTo(other) == EQUAL
+  override fun hashCode() = raw.hashCode()
+  override fun compareTo(other: MavenVersion) : Int {
+    if (raw == other.raw) return EQUAL // simple obvious case.
+    // loop through the next-to-last of the shortest.
+    val minLength = min(elements.size, other.elements.size)
+    for (i in 0..minLength - 2) {
+      elements[i].numberOrStringComparison(other.elements[i]).let {
+        cmp -> if (cmp != EQUAL) return cmp
+      }
+    }
+    // so far, all but the last element (of the shortest version) are equal.
+    // 1.3.5.2 vs. 1.3.6-RC1 or 1.3.5 vs. 1.3.05, should all make it here.
+    val a = VersionElement.from(
+        elements[minLength - 1],
+        elements.size == minLength)
+    val b = VersionElement.from(
+        other.elements[minLength - 1],
+        other.elements.size == minLength)
+    // test the last element
+    a.compareTo(b).let { comparison -> if (comparison != EQUAL) return comparison }
+    // so far, the equivalent elements all match.
+    when {
+      elements.size > other.elements.size -> return GREATER_THAN // 1.3.5 > 1.3
+      elements.size < other.elements.size -> return LESS_THAN // 1.3 < 1.3.5
+      else -> {
+        // same number of elements, check qualifiers then (if otherwise equal) snapshots.
+        val thisSplit = elements.last().removeSuffix("-SNAPSHOT").split("-", limit = 1)
+        val otherSplit = elements.last().removeSuffix("-SNAPSHOT").split("-", limit = 1)
+        when {
+          thisSplit.size < otherSplit.size -> return GREATER_THAN // 1.3.5 > 1.3.5-a
+          thisSplit.size > otherSplit.size -> return LESS_THAN // 1.3.5-a < 1.3.5
+        }
+      }
+    }
+    return EQUAL
+  }
+
+  companion object {
+    fun from(raw: String) = with(raw.split(".")) {
+      MavenVersion(raw, this, this.last().endsWith("-SNAPSHOT"))
+    }
+  }
+}
+
+
+internal data class VersionElement(
+  val core: String,
+  val qualifier: String? = null,
+  val snapshot: Boolean = false
+) : Comparable<VersionElement> {
+
+  override fun compareTo(other: VersionElement): Int {
+    var compare = core.numberOrStringComparison(other.core)
+    if (compare != 0) return compare
+    compare = when {
+      qualifier == null && other.qualifier != null -> GREATER_THAN // qualified version is lesser
+      qualifier != null && other.qualifier == null -> LESS_THAN // unqualified version is greater
+      else -> {
+        qualifier?.numberOrStringComparison(other.qualifier!!) ?: EQUAL
+      }
+    }
+    if (compare != 0) return compare
+    // qualifiers are equal or don't exist - versions are equal at this point. Checking snapshot
+    return when {
+      this.snapshot && !other.snapshot -> LESS_THAN // snapshot less than release
+      !this.snapshot && other.snapshot -> GREATER_THAN // release greater than snapshot
+      else -> EQUAL
+    }
+  }
+
+  companion object {
+    fun from(raw: String, terminal: Boolean): VersionElement {
+      require(!raw.contains(".")) { "Version elements may not contains '.' characters." }
+      return if (terminal) {
+        val noSnapshot = raw.removeSuffix("-SNAPSHOT")
+        val parts = noSnapshot.split("-", limit = 2)
+        VersionElement(
+            core = parts[0],
+            qualifier = if (parts.size == 2) parts[1] else null,
+            snapshot = raw.endsWith("-SNAPSHOT")
+        )
+      } else VersionElement(raw)
+    }
+  }
+}
+
+internal fun String.numberComparison(other: String) : Int? {
+  val a = this.toIntOrNull()
+  val b = other.toIntOrNull()
+  return if (a != null && b != null) a.compareTo(b)
+  else null
+}
+
+internal fun String.numberOrStringComparison(other: String) =
+    numberComparison(other) ?: this.compareTo(other)
+
+

--- a/src/main/java/com/squareup/tools/maven/resolution/MavenVersion.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/MavenVersion.kt
@@ -70,7 +70,7 @@ class MavenVersion private constructor(
   }
 
   companion object {
-    fun from(raw: String) = with(raw.split(".")) {
+    @JvmStatic fun from(raw: String) = with(raw.split(".")) {
       MavenVersion(raw, this, this.last().endsWith("-SNAPSHOT"))
     }
   }

--- a/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
+++ b/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
@@ -15,19 +15,22 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test
 kt_jvm_library(
     name = "testlib",
     testonly = True,
-    srcs = glob(["*.kt"], exclude = ["*Test.kt"]),
+    srcs = glob(
+        ["*.kt"],
+        exclude = ["*Test.kt"],
+    ),
     friend = "//src/main/java/com/squareup/tools/maven/resolution",
     deps = [
         "//src/main/java/com/squareup/tools/maven/resolution",
         "@maven//com/google/truth",
-    ]
+    ],
 )
 
 kt_jvm_test(
     name = "MavenVersionTest",
     srcs = ["MavenVersionTest.kt"],
-    test_class = "com.squareup.tools.maven.resolution.MavenVersionTest",
     friends = ["//src/main/java/com/squareup/tools/maven/resolution"],
+    test_class = "com.squareup.tools.maven.resolution.MavenVersionTest",
     deps = [
         "//src/main/java/com/squareup/tools/maven/resolution",
         "@maven//com/google/truth",

--- a/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
+++ b/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
@@ -24,6 +24,18 @@ kt_jvm_library(
 )
 
 kt_jvm_test(
+    name = "MavenVersionTest",
+    srcs = ["MavenVersionTest.kt"],
+    test_class = "com.squareup.tools.maven.resolution.MavenVersionTest",
+    friends = ["//src/main/java/com/squareup/tools/maven/resolution"],
+    deps = [
+        "//src/main/java/com/squareup/tools/maven/resolution",
+        "@maven//com/google/truth",
+        "@maven//junit",
+    ],
+)
+
+kt_jvm_test(
     name = "ResolutionTest",
     srcs = ["ResolutionTest.kt"],
     friend = ":testlib",

--- a/src/test/java/com/squareup/tools/maven/resolution/MavenVersionTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/MavenVersionTest.kt
@@ -133,6 +133,28 @@ class MavenVersionTest {
     assertThrows(IllegalArgumentException::class.java) { ve("5.1") }
   }
 
+  @Test fun `test sorted MavenVersions`() {
+    val actual = listOf(
+      MavenVersion.from("2.3.5-SNAPSHOT"),
+      MavenVersion.from("2.3.5"),
+      MavenVersion.from("2.0"),
+      MavenVersion.from("2a.0"),
+      MavenVersion.from("2.0-beta"),
+      MavenVersion.from("2.0-beta-SNAPSHOT"),
+      MavenVersion.from("2.3.5.2")
+    ).sorted()
+    val expected = listOf(
+      MavenVersion.from("2.0-beta-SNAPSHOT"),
+      MavenVersion.from("2.0-beta"),
+      MavenVersion.from("2.0"),
+      MavenVersion.from("2.3.5-SNAPSHOT"),
+      MavenVersion.from("2.3.5"),
+      MavenVersion.from("2.3.5.2"),
+      MavenVersion.from("2a.0") // because it's non-numeric, and so lexically comes after 2
+    )
+    assertThat(actual).isEqualTo(expected)
+  }
+
   private fun ve(raw: String, terminal: Boolean = true): VersionElement =
       VersionElement.from(raw, terminal)
 

--- a/src/test/java/com/squareup/tools/maven/resolution/MavenVersionTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/MavenVersionTest.kt
@@ -130,11 +130,11 @@ class MavenVersionTest {
   }
 
   @Test fun `test VersionElement no dots`() {
-    assertThrows(IllegalArgumentException::class.java){ ve("5.1") }
+    assertThrows(IllegalArgumentException::class.java) { ve("5.1") }
   }
 
-  private fun ve(raw: String, terminal: Boolean = true) : VersionElement =
+  private fun ve(raw: String, terminal: Boolean = true): VersionElement =
       VersionElement.from(raw, terminal)
 
-  private fun v(raw: String) : MavenVersion = MavenVersion.from(raw)
+  private fun v(raw: String): MavenVersion = MavenVersion.from(raw)
 }

--- a/src/test/java/com/squareup/tools/maven/resolution/MavenVersionTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/MavenVersionTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class MavenVersionTest {
+  @Test fun `test compare even versions`() {
+    assertThat(v("1.9.3.4")).isLessThan(v("1.10.2.5"))
+    assertThat(v("1.2")).isLessThan(v("1.3"))
+    assertThat(v("1.5.2")).isEquivalentAccordingToCompareTo(v("1.5.2"))
+  }
+
+  @Test fun `test compare uneven versions`() {
+    assertThat(v("1.9.3")).isLessThan(v("1.9.3.4"))
+
+    // this seems wrong, but the use of "." separator makes it a sub-version, not a qualified version
+    assertThat(v("1.9.3")).isLessThan(v("1.9.3.alpha"))
+  }
+
+  @Test fun `test compare qualified versions`() {
+    assertThat(v("1.5.2-RC1")).isEquivalentAccordingToCompareTo(v("1.5.2-RC1"))
+    assertThat(v("1.5.2-RC1")).isLessThan(v("1.5.2-RC2"))
+
+    // This is contrary to developer expectation, but "beta" isn't a separator. so this is lexically
+    // sorted
+    // TODO special case alpha/beta/gamma/rc and treat them as special separators
+    assertThat(v("1.5.2beta10")).isLessThan(v("1.5.2beta2"))
+  }
+
+  @Test fun `test plain greater than qualified`() {
+    assertThat(v("1.5.2")).isGreaterThan(v("1.5.2-RC1"))
+    assertThat(v("1.5.2-RC1")).isLessThan(v("1.5.2"))
+    assertThat(v("1.5.2")).isGreaterThan(v("1.5.2-beta"))
+  }
+
+  @Test fun `test unseparated qualifiers`() {
+    assertThat(v("1.5.2")).isLessThan(v("1.5.2beta2")) // TODO fix this.
+  }
+
+  @Test fun `test release greater than snapshots`() {
+    assertThat(v("1.5.2")).isGreaterThan(v("1.5.2-SNAPSHOT"))
+    assertThat(v("1.5.2-beta")).isGreaterThan(v("1.5.2-beta-SNAPSHOT"))
+    assertThat(v("1.5.2alpha1")).isGreaterThan(v("1.5.2alpha1-SNAPSHOT"))
+  }
+
+  @Test fun `test short versions`() {
+    assertThat(v("1")).isEquivalentAccordingToCompareTo(v("1"))
+    assertThat(v("1")).isLessThan(v("2"))
+    assertThat(v("2")).isGreaterThan(v("1"))
+    assertThat(v("1-SNAPSHOT")).isLessThan(v("1"))
+    assertThat(v("1-beta")).isLessThan(v("1"))
+  }
+
+  @Test fun `test numericCompareTo both numbers`() {
+    assertThat("5".numberOrStringComparison("5") == 0).isTrue()
+    assertThat("4".numberOrStringComparison("5") < 0).isTrue()
+    assertThat("5".numberOrStringComparison("4") > 0).isTrue()
+    assertThat("10".numberOrStringComparison("9") > 0).isTrue()
+  }
+
+  @Test fun `test numericCompareTo both non-numbers`() {
+    assertThat("a5".numberOrStringComparison("a5") == 0).isTrue()
+    assertThat("4a".numberOrStringComparison("5a") < 0).isTrue()
+    assertThat("c5".numberOrStringComparison("c4") > 0).isTrue()
+    assertThat("a10".numberOrStringComparison("a9") < 0).isTrue()
+  }
+
+  @Test fun `test VersionElement no qualifiers`() {
+    assertThat(ve("5")).isEquivalentAccordingToCompareTo(ve("5"))
+    assertThat(ve("5")).isLessThan(ve("6"))
+    assertThat(ve("6")).isGreaterThan(ve("5"))
+    assertThat(ve("a10")).isLessThan(ve("a9")) // not a number, lexical ordering.
+  }
+
+  @Test fun `test VersionElement with qualifiers`() {
+    assertThat(ve("5-1")).isLessThan(ve("5-2")) // numeric qualifier
+    assertThat(ve("5-01")).isLessThan(ve("5-2")) // numeric qualifier with extra steps
+
+    assertThat(ve("5")).isGreaterThan(ve("5-2")) // no qualifier
+    assertThat(ve("5-RC1")).isLessThan(ve("5")) // no qualifier
+  }
+
+  // These special cases aren't yet handled, so this test confirms they're lexically sorted.
+  // TODO handle these cases specially.
+  @Test fun `test VersionElement with special-case qualifiers`() {
+    assertThat(ve("5")).isLessThan(ve("5beta")) // numeric qualifier
+    assertThat(ve("5beta10")).isLessThan(ve("5beta2")) // numeric qualifier with extra steps
+    assertThat(ve("5-RC10")).isLessThan(ve("5-RC2")) // qualifier isn't numeric
+    assertThat(ve("5-beta1")).isGreaterThan(ve("5-2")) // not a number, lexical ordering.
+  }
+
+  @Test fun `test VersionElement with snapshots`() {
+    assertThat(ve("5")).isGreaterThan(ve("5-SNAPSHOT"))
+    assertThat(ve("5-SNAPSHOT")).isLessThan(ve("5")) // Release trumps snapshot
+
+    // 5 is greater than 5-2, even 5-snapshot. 5 and 5-2 are compared first.
+    assertThat(ve("5-SNAPSHOT")).isGreaterThan(ve("5-2"))
+  }
+
+  @Test fun `test VersionElement terminal with non-terminal`() {
+    assertThat(ve("5", false)).isGreaterThan(ve("5-SNAPSHOT"))
+    assertThat(ve("6", false)).isGreaterThan(ve("5-SNAPSHOT"))
+    assertThat(ve("5-a", false)).isGreaterThan(ve("5-SNAPSHOT"))
+    assertThat(ve("5a", false)).isGreaterThan(ve("5a-SNAPSHOT"))
+
+    // This one is counter-intuitive, but because non-terminal version numbers don't have
+    // qualifiers, and terminal ones do, 5-a is treated as "raw", but it's compared to "5"
+    // (from 5-a-SNAPSHOT), because the latter is terminal, so it's parsed. "5-a" is lexically
+    // greater than "5" (since it's not a numeric, because the former isn't parsed), so we get
+    // the below behavior.
+    // This is a rare edge-case (comparing 1.3.5-a.4 vs. 1.3.5-a-SNAPSHOT). These are incoherent
+    // version numbers and there's no good way to interpret them.
+    assertThat(ve("5-a", false)).isGreaterThan(ve("5-a-SNAPSHOT"))
+  }
+
+  @Test fun `test VersionElement no dots`() {
+    assertThrows(IllegalArgumentException::class.java){ ve("5.1") }
+  }
+
+  private fun ve(raw: String, terminal: Boolean = true) : VersionElement =
+      VersionElement.from(raw, terminal)
+
+  private fun v(raw: String) : MavenVersion = MavenVersion.from(raw)
+}


### PR DESCRIPTION
Add in a wrapper for maven versions, so they can be compared using maven 3 comparison logic.

This isn't (yet) used anywhere in resolution, but is a feature needed in both places I'm using this library, and it seems more appropriate to have it here than in its own artifact.