### PR TITLE
Add proxy support

### DIFF
--- a/src/main/java/com/squareup/tools/maven/resolution/ProxyHelper.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ProxyHelper.kt
@@ -1,0 +1,150 @@
+package com.squareup.tools.maven.resolution
+
+import okhttp3.Authenticator
+import okhttp3.Credentials
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+import java.net.URI
+import java.net.Proxy
+import java.net.InetSocketAddress
+import java.util.regex.Pattern
+
+sealed class ProxyEnvParseResult {
+  object NoConfig : ProxyEnvParseResult()
+
+  data class Error(val errorMessage: String) : ProxyEnvParseResult()
+
+  data class ProxyConfig(
+    val protocol: String,
+    val username: String?,
+    val password: String?,
+    val hostname: String,
+    val port: Int
+  ) : ProxyEnvParseResult() {
+    override fun toString(): String {
+      return "${protocol}://${hostname}:${port}"
+    }
+  }
+}
+
+sealed class ProxyExemptParseResult {
+  object NoProxyConfigured : ProxyExemptParseResult()
+
+  data class Error(val errorMessage: String) : ProxyExemptParseResult()
+  data class Exempt(val url: String) : ProxyExemptParseResult()
+  data class NotExempt(val proxy: Proxy) : ProxyExemptParseResult()
+}
+
+object ProxyUtils {
+
+  fun getConfig(proxyAddress: String = System.getenv("https_proxy") ?: System.getenv("HTTPS_PROXY")): ProxyEnvParseResult {
+    val urlPattern =
+      Pattern.compile("^(https?)://(([^:@]+?)(?::([^@]+?))?@)?([^:]+)(?::(\\d+))?/?$")
+    val matcher = urlPattern.matcher(proxyAddress)
+    if (!matcher.matches()) {
+      return ProxyEnvParseResult.Error("Proxy address $proxyAddress is not a valid URL")
+    }
+
+    val protocol = matcher.group(1)
+    val idAndPassword = matcher.group(2)
+    val username = matcher.group(3)
+    val password = matcher.group(4)
+    val hostname = matcher.group(5)
+    val portRaw = matcher.group(6)
+
+    val https: Boolean
+    https = when (protocol) {
+      "https" -> true
+      "http" -> false
+      else -> return ProxyEnvParseResult.Error("Invalid proxy protocol for $proxyAddress")
+    }
+    var port = if (https) 443 else 80 // Default port numbers
+    if (portRaw != null) {
+      port = try {
+        portRaw.toInt()
+      } catch (e: NumberFormatException) {
+        return ProxyEnvParseResult.Error("Error parsing proxy port: $proxyAddress ${e}")
+      }
+    }
+
+    if (username != null) {
+      if (password == null) {
+        return ProxyEnvParseResult.Error("No password given for proxy $proxyAddress")
+      }
+    }
+
+    return ProxyEnvParseResult.ProxyConfig(
+      protocol = protocol, username = username, password = password, hostname = hostname,
+      port = port
+    )
+  }
+
+  fun checkUrlIfProxyExempt(
+    proxyEnvConfig: ProxyEnvParseResult,
+    requestedUrl: String,
+    noProxyUrl: String? = System.getenv("no_proxy") ?: System.getenv("NO_PROXY")
+  ): ProxyExemptParseResult {
+
+    if (proxyEnvConfig !is ProxyEnvParseResult.ProxyConfig) {
+      return ProxyExemptParseResult.NoProxyConfigured
+    }
+
+    if (!noProxyUrl.isNullOrEmpty()) {
+      val noProxyUrlArray: Array<String> = noProxyUrl.split(",".toRegex())
+        .toTypedArray()
+      val uri = URI(requestedUrl)
+
+      val requestedHost: String = uri.getHost()
+      for (i in noProxyUrlArray.indices) {
+        if (noProxyUrlArray[i]
+            .startsWith(".")
+        ) {
+          // This entry applies to sub-domains only.
+          if (requestedHost.endsWith(noProxyUrlArray[i])) {
+            return ProxyExemptParseResult.Exempt(noProxyUrlArray[i])
+          }
+        } else {
+          // This entry applies to the literal hostname and sub-domains.
+          if (requestedHost == noProxyUrlArray[i] || requestedHost.endsWith(
+              "." + noProxyUrlArray[i]
+            )
+          ) {
+            return ProxyExemptParseResult.Exempt(noProxyUrlArray[i])
+          }
+        }
+      }
+    }
+
+    val proxy = Proxy(Proxy.Type.HTTP, InetSocketAddress(proxyEnvConfig.hostname, proxyEnvConfig.port))
+    return ProxyExemptParseResult.NotExempt(proxy)
+  }
+
+  fun createAuthenticatorIfNecessary(proxyEnvConfig: ProxyEnvParseResult) : Authenticator? {
+    // Here there be dragons.
+    if (proxyEnvConfig is ProxyEnvParseResult.ProxyConfig) {
+      if (proxyEnvConfig.username != null && proxyEnvConfig.password != null) {
+        info { "Setting proxy configuration $proxyEnvConfig" }
+
+        val credentials = Credentials.basic(proxyEnvConfig.username, proxyEnvConfig.password)
+
+        val proxyAuthenticator = object : Authenticator {
+          override fun authenticate(
+            route: Route?,
+            response: Response
+          ): Request? {
+            val request = response.request
+
+            return request
+              .newBuilder()
+              .header("Proxy-Authorization", credentials)
+              .build()
+          }
+        }
+        return proxyAuthenticator
+      }
+    }
+    return null
+  }
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
+++ b/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
@@ -50,3 +50,16 @@ kt_jvm_test(
         "@maven//junit",
     ],
 )
+
+kt_jvm_test(
+    name = "HttpProxyTest",
+    srcs = ["HttpProxyTest.kt"],
+    friend = ":testlib",
+    test_class = "com.squareup.tools.maven.resolution.HttpProxyTest",
+    deps = [
+        ":testlib",
+        "//src/main/java/com/squareup/tools/maven/resolution",
+        "@maven//com/google/truth",
+        "@maven//junit",
+    ],
+)

--- a/src/test/java/com/squareup/tools/maven/resolution/HttpProxyTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/HttpProxyTest.kt
@@ -1,0 +1,67 @@
+package com.squareup.tools.maven.resolution
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.tools.maven.resolution.ProxyEnvParseResult.ProxyConfig
+import okhttp3.Authenticator
+import org.junit.Test
+
+class HttpProxyTest {
+
+  @Test fun testHttpProxyParsing() {
+    val result = ProxyUtils.getConfig("http://www.myproxy.com")
+    assertThat(result).isInstanceOf(ProxyEnvParseResult.ProxyConfig::class.java)
+    val proxyConfig = result as ProxyConfig
+
+    assertThat(proxyConfig.hostname).isEqualTo("www.myproxy.com")
+    assertThat(proxyConfig.port).isEqualTo(80)
+  }
+
+  @Test fun testHttpsProxyParsing() {
+    val result = ProxyUtils.getConfig("https://www.myproxy.com")
+    assertThat(result).isInstanceOf(ProxyEnvParseResult.ProxyConfig::class.java)
+    val proxyConfig = result as ProxyConfig
+
+    assertThat(proxyConfig.hostname).isEqualTo("www.myproxy.com")
+    assertThat(proxyConfig.port).isEqualTo(443)
+  }
+
+  @Test fun testProxyParsingError() {
+    val result = ProxyUtils.getConfig("http:/www.myproxy.com")
+    assertThat(result).isInstanceOf(ProxyEnvParseResult.Error::class.java)
+  }
+
+  @Test fun testProxyUserNamePassword() {
+    val result = ProxyUtils.getConfig("https://userid:password@www.myproxy.com")
+    assertThat(result).isInstanceOf(ProxyEnvParseResult.ProxyConfig::class.java)
+
+    val proxyConfig = result as ProxyConfig
+    assertThat(proxyConfig.hostname).isEqualTo("www.myproxy.com")
+    assertThat(proxyConfig.port).isEqualTo(443)
+    assertThat(proxyConfig.username).isEqualTo("userid")
+    assertThat(proxyConfig.password).isEqualTo("password")
+  }
+
+  @Test fun testProxyExempt() {
+    val proxyConfig = ProxyUtils.getConfig("http://www.myproxy.com")
+    var result = ProxyUtils.checkUrlIfProxyExempt(proxyConfig, "http://www.cnn.com", ".cnn.com")
+    assertThat(result).isInstanceOf(ProxyExemptParseResult.Exempt::class.java)
+  }
+
+  @Test fun testProxyNotExempt() {
+    val proxyConfig = ProxyUtils.getConfig("http://www.myproxy.com")
+    var result = ProxyUtils.checkUrlIfProxyExempt(proxyConfig, "http://www.cnn.com", ".abcnews.com")
+    assertThat(result).isInstanceOf(ProxyExemptParseResult.NotExempt::class.java)
+  }
+
+  @Test fun testAuthenticator() {
+    val proxyConfig = ProxyUtils.getConfig("https://userid:password@www.myproxy.com")
+    val result = ProxyUtils.createAuthenticatorIfNecessary(proxyConfig)
+    assertThat(result).isInstanceOf(Authenticator::class.java)
+  }
+
+  @Test fun testNoAuthenticator() {
+    val proxyConfig = ProxyUtils.getConfig("https://www.myproxy.com")
+    val result = ProxyUtils.createAuthenticatorIfNecessary(proxyConfig)
+    assertThat(result).isNull()
+  }
+}


### PR DESCRIPTION
Looks for the https_proxy environment variable and parses out the info to create the OkHttpClient proxy settings necessary.    This code was taken from the [ProxyHelper](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/ProxyHelper.java#L52) from Bazel Java code.

Tested but requires me to setup bazel_maven_repository to compile the local code instead of pulling from the Maven repo:


```
+++ b/kramer/WORKSPACE
@@ -19,6 +19,11 @@ http_archive(
 #    path = "..",
 #)
+local_repository(
+    name = "maven_archeologist",
+    path = "/Users/rogerh/Development/maven-archeologist",
+)
+
 load("@maven_repository_rules//maven:maven.bzl", "maven_repository_specification")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
diff --git a/kramer/src/main/kotlin/kramer/BUILD.bazel b/kramer/src/main/kotlin/kramer/BUILD.bazel
index 62bb2ed..eebb28b 100644
--- a/kramer/src/main/kotlin/kramer/BUILD.bazel
+++ b/kramer/src/main/kotlin/kramer/BUILD.bazel
@@ -22,7 +22,7 @@ kt_jvm_library(
         "@maven//com/google/guava",
         "@maven//com/squareup/moshi",
         "@maven//com/squareup/moshi:moshi-kotlin",
-        "@maven//com/squareup/tools/build:maven-archeologist",
+        "@maven_archeologist//src/main/java/com/squareup/tools/maven/resolution",
         "@maven//org/jetbrains/kotlin:kotlin-stdlib",
         "@maven//org/jetbrains/kotlinx:kotlinx-coroutines-core",
     ],
```

Then I had to set visibility of this package for it to compile:

```
--- a/src/main/java/com/squareup/tools/maven/resolution/BUILD.bazel
+++ b/src/main/java/com/squareup/tools/maven/resolution/BUILD.bazel
@@ -11,7 +11,7 @@
 # the License.
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
-package(default_visibility = ["//:__subpackages__"])
+package(default_visibility = ["//visibility:public"])
```