### PR TITLE
reuse OkHttpClient instance

### DIFF
--- a/src/main/java/com/squareup/tools/maven/resolution/HttpArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/HttpArtifactFetcher.kt
@@ -43,7 +43,7 @@ class HttpArtifactFetcher(
   /** The path to the local artifact cache. */
   cacheDir: Path,
   /** A function to return an [OkHttpClient], possibly configured for proxies, filtered by url */
-  private val client: (url: String) -> OkHttpClient = ProxyHelper::createProxyingClientFromEnv
+  private val client: OkHttpClient = OkHttpClient()
 ) : AbstractArtifactFetcher(cacheDir) {
 
   override fun fetchFile(
@@ -53,7 +53,9 @@ class HttpArtifactFetcher(
   ): RepositoryFetchStatus {
     val url = "${repository.url}/$path"
     val request: Request = Builder().url(url).build()
-    return client(url).newCall(request)
+    val proxiedClient = ProxyHelper.createProxyingClientFromEnv(url, client)
+
+    return proxiedClient.newCall(request)
         .also { info { "About to fetch $url" } }
         .execute()
         .use { response ->

--- a/src/main/java/com/squareup/tools/maven/resolution/ProxyHelper.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ProxyHelper.kt
@@ -55,14 +55,14 @@ object ProxyHelper {
     else -> throw IllegalStateException("Invalid proxy protocol")
   }
 
-  fun createProxyingClientFromEnv(url: String): OkHttpClient {
-    val builder = OkHttpClient.Builder()
+  fun createProxyingClientFromEnv(url: String, client: OkHttpClient): OkHttpClient {
     val exemptResult = config.isExempt(url, getenv("no_proxy") ?: getenv("NO_PROXY"))
     if (exemptResult is NotExempt) {
+      val builder = client.newBuilder()
       builder.proxy(exemptResult.proxy)
       config.authenticator()?.let { builder.authenticator(it) }
     }
-    return builder.build()
+    return client
   }
 }
 


### PR DESCRIPTION
Based on https://square.github.io/okhttp/4.x/okhttp/okhttp3/-ok-http-client/#okhttpclients-should-be-shared

..or would you prefer https://github.com/square/maven-archeologist/pull/19?