### PR TITLE
Return status for resolution and handle connection exceptions

### DIFF
--- a/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
@@ -57,6 +57,7 @@ internal fun MutableMap<String, String>.fakeArtifact(
   pomContent: String,
   fileContent: String,
   sourceContent: String? = null,
+  realHash: Boolean = true,
   classifiedFiles: Map<String, Pair<String, String>> = mapOf() // classifier=(content=suffix)
 ): MutableMap<String, String> {
   val (groupId, artifactId, version) = coordinate.split(':')
@@ -64,21 +65,21 @@ internal fun MutableMap<String, String>.fakeArtifact(
   val dir = "$repoUrl/$groupPath/$artifactId/$version"
   val filePrefix = "$artifactId-$version"
   put("$dir/$filePrefix.pom", pomContent)
-  put("$dir/$filePrefix.pom.sha1", pomContent.sha1())
-  put("$dir/$filePrefix.pom.md5", pomContent.md5())
+  put("$dir/$filePrefix.pom.sha1", if (realHash) pomContent.sha1() else "badhash")
+  put("$dir/$filePrefix.pom.md5", if (realHash) pomContent.md5() else "badhash")
   put("$dir/$filePrefix.$suffix", fileContent)
-  put("$dir/$filePrefix.$suffix.sha1", fileContent.sha1())
-  put("$dir/$filePrefix.$suffix.md5", fileContent.md5())
+  put("$dir/$filePrefix.$suffix.sha1", if (realHash) fileContent.sha1() else "badhash")
+  put("$dir/$filePrefix.$suffix.md5", if (realHash) fileContent.md5() else "badhash")
   if (sourceContent != null) {
     put("$dir/$filePrefix-sources.jar", sourceContent)
-    put("$dir/$filePrefix-sources.jar.sha1", sourceContent.sha1())
-    put("$dir/$filePrefix-sources.jar.md5", sourceContent.md5())
+    put("$dir/$filePrefix-sources.jar.sha1", if (realHash) sourceContent.sha1() else "badhash")
+    put("$dir/$filePrefix-sources.jar.md5", if (realHash) sourceContent.md5() else "badhash")
   }
   for ((classifier, value) in classifiedFiles) {
     val (content, suffix) = value // can't nest destructuring
     put("$dir/$filePrefix-$classifier.$suffix", content)
-    put("$dir/$filePrefix-$classifier.$suffix.sha1", content.sha1())
-    put("$dir/$filePrefix-$classifier.$suffix.md5", content.md5())
+    put("$dir/$filePrefix-$classifier.$suffix.sha1", if (realHash) content.sha1() else "badhash")
+    put("$dir/$filePrefix-$classifier.$suffix.md5", if (realHash) content.md5() else "badhash")
   }
   return this
 }


### PR DESCRIPTION
Return an articulated set of statuses (the same as are returned for artifact fetching) for the resolution step, creating a new API for this mode (and deprecating the old method, basing its current behavior on this new api).  

Additionally, make sure that exceptions thrown during http request execution are trapped and an error state is properly returned, instead of propagating the exception accidentally into the calling code. The error status includes the thrown exception, so that metadata is available to the client if needed.

The old API will stay until version 1.0 and then be deleted.

This new mode doesn't log spam on errors in resolution, but instead offers a resolution result which contains both the status of the fetching of the poms, and (if applicable) the resolved artifact or null, as before.  This lets the client deal with the error, and how to log/handle it, and the API is also, then, a bit more of a parallel to the artifact downloading. The return API isn't purely the status, but the flow is "ask the method to resolve, check the result, do the next thing" for all of the main (non-simplified) methods of ArtifactResolver.