### PR TITLE
Add support for fetching and parsing Gradle module files.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,30 +9,31 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-workspace(name = "maven_archologist")
+workspace(name = "maven_archeologist")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//:versions.bzl",
-    "KOTLINC_RELEASE_URL",
     "KOTLINC_RELEASE_SHA",
-    "KOTLIN_RULES_URL",
+    "KOTLINC_RELEASE_URL",
     "KOTLIN_RULES_SHA",
-    "maven_artifacts",
-    "MAVEN_REPOSITORY_RULES_VERSION",
+    "KOTLIN_RULES_URL",
     "MAVEN_REPOSITORY_RULES_SHA",
+    "MAVEN_REPOSITORY_RULES_VERSION",
+    "maven_artifacts",
 )
 
 # Load the kotlin rules repository, and setup kotlin rules and toolchain.
 http_archive(
     name = "io_bazel_rules_kotlin",
-    urls = [ KOTLIN_RULES_URL ],
     sha256 = KOTLIN_RULES_SHA,
+    urls = [KOTLIN_RULES_URL],
 )
+
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
 kotlin_repositories(compiler_release = {
-    "urls": [ KOTLINC_RELEASE_URL ],
+    "urls": [KOTLINC_RELEASE_URL],
     "sha256": KOTLINC_RELEASE_SHA,
 })
 

--- a/src/main/java/com/squareup/tools/maven/resolution/ArtifactFetcher.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ArtifactFetcher.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.tools.maven.resolution
 
-import org.apache.maven.model.Repository
 import kotlin.DeprecationLevel.WARNING
+import org.apache.maven.model.Repository
 
 sealed class FetchStatus {
   sealed class RepositoryFetchStatus : FetchStatus() {
@@ -62,9 +62,20 @@ interface ArtifactFetcher {
   fun fetchArtifact(artifactFile: ArtifactFile, repositories: List<Repository>): FetchStatus
 
   /**
-   * Performs a fetch against any repositories offered (in order), downloads the artifact file (and any
-   * hash files), and if it finds it, performs validation. Returns false if the file wasn't fetched,
-   * or if the file's validation failed.
+   * Performs a fetche against any repositories offered (in order), downloads the artifact file
+   * (and any hash files), and, if it finds them, performs content hash validation. Returns a
+   * [FetchStatus] describing the outcome. The file will be written to the [FileSpec.localFile]
+   * of the given [file], or discovered there, if previously downloaded.
    */
-  fun fetchFile(fetchFile: FileSpec, repositories: List<Repository>): FetchStatus
+  fun fetchFile(file: FileSpec, repositories: List<Repository>): FetchStatus
+
+  /**
+   * Performs fetches against any repositories offered (in order), downloads the artifact files
+   * (and any hash files), and, if it finds them, performs content hash validation. Returns a
+   * map of [FileSpec]s to [FetchStatus]es based the outcome. The files will be written to the
+   * [FileSpec.localFile] of the given [files], or discovered there, if previously downloaded.
+   *
+   * This method may perform serialized or parallel fetches, as determined by the implementation.
+   */
+  fun fetchFiles(vararg files: FileSpec, repositories: List<Repository>): Map<FileSpec, FetchStatus>
 }

--- a/src/main/java/com/squareup/tools/maven/resolution/demo/simple/ResolveArtifact.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/demo/simple/ResolveArtifact.kt
@@ -74,7 +74,7 @@ class Resolve : CliktCommand() {
     artifacts
         .map { resolver.artifactFor(it) }
         .forEach { artifact ->
-          val resolvedArtifact = resolver.resolveArtifact(artifact)
+          val resolvedArtifact = resolver.resolve(artifact).artifact
           resolvedArtifact?.apply {
             report(
                 "Artifact model for ${resolvedArtifact.coordinate} successfully resolved.")

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/BUILD.bazel
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/BUILD.bazel
@@ -14,17 +14,12 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 package(default_visibility = ["//:__subpackages__"])
 
 kt_jvm_library(
-    name = "resolution",
+    name = "gradle",
     srcs = glob(["*.kt"]),
     deps = [
-        "//src/main/java/com/squareup/tools/maven/resolution/gradle",
         "@maven//com/squareup/moshi",
         "@maven//com/squareup/moshi:moshi-kotlin",
-        "@maven//com/squareup/okhttp3:okhttp",
         "@maven//com/squareup/okio",
-        "@maven//org/apache/maven:maven-builder-support",
-        "@maven//org/apache/maven:maven-model",
-        "@maven//org/apache/maven:maven-model-builder",
     ],
 )
 

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/GradleModuleParser.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/GradleModuleParser.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import com.squareup.tools.maven.resolution.gradle.Module.ModuleV1_1
+import java.io.IOException
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption.READ
+import okio.Source
+import okio.buffer
+import okio.source
+
+class GradleModuleParser(
+  val moshi: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+) {
+
+  @Throws(IOException::class)
+  fun parse(json: Path): Module? = parse(json.source(READ))
+
+  @Throws(IOException::class)
+  fun parse(json: Source): Module? {
+    json.use { source ->
+      val reader = JsonReader.of(source.buffer())
+      // TODO(cgruber) handle module format versions by peeking the format.
+      // For now, just pipe them all to 1.1, since 1.0 is backward compatible.
+      // val peeker = reader.peekJson()
+      val adapter = moshi.adapter(ModuleV1_1::class.java).failOnUnknown()
+      return adapter.fromJson(reader)
+    }
+  }
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/Module.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/Module.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+import com.squareup.tools.maven.resolution.gradle.ModuleComponent.ModuleComponentV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleVariant.ModuleVariantV1_1
+
+sealed class Module {
+  /** Which version of the gradle module specification does this json conform to? */
+  abstract val formatVersion: String
+
+  /**
+   * Details what system created this file. (typically gradle, with version and buildId). There
+   * should only be one entry.  This could be a stronger type, but there's no reason to fail
+   * if there's variance, so
+   */
+  abstract val createdBy: Map<String, Map<String, String>>
+
+  abstract val component: ModuleComponent
+
+  abstract val variants: List<ModuleVariant>
+
+  data class ModuleV1_1(
+    override val formatVersion: String,
+    override val createdBy: Map<String, Map<String, String>>,
+    override val component: ModuleComponentV1_1,
+    override val variants: List<ModuleVariantV1_1>
+  ) : Module() {
+    init {
+      assert(formatVersion in setOf("1.0", "1.1")) {
+        "Parsed Gradle Module declaring format version $formatVersion with 1.1 model objects."
+      }
+    }
+  }
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleCapabilities.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleCapabilities.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+/**
+ * An identifier for a capability, typically attributed by some plugin, affecting the output
+ * artifact, and used as a part of a selector for a specific artifact.
+ */
+sealed class ModuleCapabilities {
+  /** corresponds to a maven group_id */
+  abstract val group: String
+
+  /** corresponds to a maven artifact_id */
+  abstract val module: String
+
+  /** corresponds to a maven version */
+  abstract val version: String
+
+  /** The core identity definition of a gradle component */
+  data class ModuleCapabilitiesV1_1(
+    override val group: String,
+    override val module: String,
+    override val version: String
+  ) : ModuleCapabilities()
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleComponent.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleComponent.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+/** The core identity definition of a gradle component */
+sealed class ModuleComponent {
+  /** corresponds to a maven group_id */
+  abstract val group: String
+
+  /** corresponds to a maven artifact_id */
+  abstract val module: String
+
+  /** corresponds to a maven version */
+  abstract val version: String
+
+  abstract val url: String?
+
+  abstract val attributes: Map<String, Any>
+
+  /** The core identity definition of a gradle component */
+  data class ModuleComponentV1_1(
+    override val group: String,
+    override val module: String,
+    override val version: String,
+    override val url: String? = null,
+    override val attributes: Map<String, Any> = mapOf()
+  ) : ModuleComponent()
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleDependency.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleDependency.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+import com.squareup.tools.maven.resolution.gradle.ArtifactSelector.ArtifactSelectorV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleCapabilities.ModuleCapabilitiesV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleDependencyExclude.ModuleDependencyExcludeV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleDependencyThirdPartCompatibility.ModuleDependencyThirdPartCompatibilityV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleVersionConstraint.ModuleVersionConstraintV1_1
+
+/**
+ * Represents a dependency reference, including its coordinates and special characteristics,
+ * such as exclusions.
+ */
+sealed class ModuleDependency {
+  /** The group of the artifact referenced by this dependency, equivalent to a maven group_id */
+  abstract val group: String
+
+  /**
+   * The module name of the artifact referenced by this dependency, equivalent to a maven
+   * artifact_id
+   */
+  abstract val module: String
+
+  /**
+   * The version requirements of this dependency, similar to a maven version specification.
+   * It may specify constraints such as ranges, excluded versions, etc.
+   */
+  abstract val version: ModuleVersionConstraint
+
+  /**
+   * Dependency exclusions, intended to trim the transitive dependency graph at this edge.
+   */
+  abstract val excludes: List<ModuleDependencyExclude>
+
+  /** A text description of the reason why this dependency exists. */
+  abstract val reason: String?
+
+  /** Gradle attributes, which may inform this dependency. */
+  abstract val attributes: Map<String, Any>
+
+  /** A text description of the reason why this dependency exists. */
+  abstract val requestedCapabilities: List<ModuleCapabilities>
+
+  /**
+   * all strict versions of the target module will be treated as if they were defined on the
+   * variant defining this dependency.
+   *
+   * TODO(cgruber) Clarify what the heck this means.
+   */
+  abstract val endorseStrictVersions: Boolean
+
+  /**
+   * additional information to be used if the dependency points at a module that did not
+   * publish Gradle module metadata. Typically this references a maven classifier, etc.
+   */
+  abstract val thirdPartyCompatibility: ModuleDependencyThirdPartCompatibility?
+
+  data class ModuleDependencyV1_1(
+    override val group: String,
+    override val module: String,
+    override val version: ModuleVersionConstraintV1_1,
+    override val excludes: List<ModuleDependencyExcludeV1_1> = listOf(),
+    override val reason: String? = null,
+    override val attributes: Map<String, Any> = mapOf(),
+    override val requestedCapabilities: List<ModuleCapabilitiesV1_1> = listOf(),
+    override val endorseStrictVersions: Boolean = false,
+    override val thirdPartyCompatibility: ModuleDependencyThirdPartCompatibilityV1_1? = null
+  ) : ModuleDependency()
+}
+
+/** An exclusion consisting of a group and a module name */
+sealed class ModuleDependencyExclude {
+  abstract val group: String
+  abstract val module: String
+
+  data class ModuleDependencyExcludeV1_1(
+    override val group: String,
+    override val module: String
+  ) : ModuleDependencyExclude()
+}
+
+sealed class ModuleDependencyThirdPartCompatibility {
+  abstract val artifactSelector: ArtifactSelector
+
+  data class ModuleDependencyThirdPartCompatibilityV1_1(
+    override val artifactSelector: ArtifactSelectorV1_1
+  ) : ModuleDependencyThirdPartCompatibility()
+}
+
+sealed class ArtifactSelector {
+  abstract val name: String
+  abstract val type: String
+  abstract val extension: String?
+  abstract val classifier: String?
+
+  data class ArtifactSelectorV1_1(
+    override val name: String,
+    override val type: String,
+    override val extension: String?,
+    override val classifier: String?
+  ) : ArtifactSelector()
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleDependencyConstraint.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleDependencyConstraint.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+import com.squareup.tools.maven.resolution.gradle.ModuleVersionConstraint.ModuleVersionConstraintV1_1
+
+sealed class ModuleDependencyConstraint {
+  abstract val group: String
+  abstract val module: String
+  abstract val version: ModuleVersionConstraint
+
+  data class ModuleDependencyConstraintV1_1(
+    override val group: String,
+    override val module: String,
+    override val version: ModuleVersionConstraintV1_1
+  ) : ModuleDependencyConstraint()
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleFile.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleFile.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+/** Represents a file reference, including name, location, and content characteristics. */
+sealed class ModuleFile {
+  abstract val name: String
+  abstract val url: String
+  abstract val size: Long
+  abstract val md5: String?
+  abstract val sha1: String?
+  abstract val sha256: String?
+  abstract val sha512: String?
+
+  data class ModuleFileV1_1(
+    override val name: String,
+    override val url: String,
+    override val size: Long,
+    override val md5: String? = null,
+    override val sha1: String? = null,
+    override val sha256: String? = null,
+    override val sha512: String? = null
+  ) : ModuleFile()
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleVariant.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleVariant.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+import com.squareup.moshi.Json
+import com.squareup.tools.maven.resolution.gradle.AvailableAt.AvailableAtV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleDependency.ModuleDependencyV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleDependencyConstraint.ModuleDependencyConstraintV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleFile.ModuleFileV1_1
+
+/**
+ * A unique variant, unique in [name], and unique in Pair([attributes], [capabilities]), so these
+ * can be used as selectors.  Systems which support this variant system may be supplied with
+ * attributes and constraints, such that a variant can be selected. No combination of attributes
+ * and capabilities may be shared by more than one named variant.
+ */
+sealed class ModuleVariant {
+  abstract val name: String
+
+  /** Attributes that distinguish this variant from others (and supply configuration information) */
+  abstract val attributes: Map<String, Any>
+  /** Capabilities that distinguish this variant from others. */
+  abstract val capabilities: Map<String, String>
+
+  // Define the variant - mutually exclusive with available-at
+  abstract val dependencies: List<ModuleDependency>
+  abstract val files: List<ModuleFile>
+  abstract val dependencyConstraints: List<ModuleDependencyConstraint>
+
+  // Redirects to another artifact for variant definition - mutually incompatible with
+  // dependencies, files, dependencyConstraints, and capabilities.
+  abstract val availableAt: AvailableAt?
+
+  protected fun validate() {
+    require((availableAt == null) ||
+        (files.isEmpty() && dependencyConstraints.isEmpty() && dependencies.isEmpty())
+    ) {
+      "If avaliable-at is set then " +
+        "neither files nor dependencyConstraints nor dependencies may be set on a variant"
+    }
+  }
+
+  class ModuleVariantV1_1(
+    override val name: String,
+    override val attributes: Map<String, Any> = mapOf(),
+    override val capabilities: Map<String, String> = mapOf(),
+    override val dependencies: List<ModuleDependencyV1_1> = listOf(),
+    override val files: List<ModuleFileV1_1> = listOf(),
+    override val dependencyConstraints: List<ModuleDependencyConstraintV1_1> = listOf(),
+    @Json(name = "available-at")
+    override val availableAt: AvailableAtV1_1? = null
+  ) : ModuleVariant() {
+    init { this.validate() }
+  }
+}
+
+/**
+ * A variant redirection signal. Mutually incompatible with [ModuleVariant.files],
+ * [ModuleVariant.dependencies], and [ModuleVariant.dependencyConstraints].
+ */
+sealed class AvailableAt {
+  /** corresponds to a maven group_id */
+  abstract val group: String
+
+  /** corresponds to a maven artifact_id */
+  abstract val module: String
+
+  /** corresponds to a maven version */
+  abstract val version: String
+
+  /** A location which may be a proper UI, or a relative path to this file's location */
+  abstract val url: String?
+
+  data class AvailableAtV1_1(
+    override val group: String,
+    override val module: String,
+    override val version: String,
+    override val url: String? = null
+  ) : AvailableAt()
+}

--- a/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleVersionConstraint.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/gradle/ModuleVersionConstraint.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tools.maven.resolution.gradle
+
+/**
+ * A constraint to indicate a version, a range of versions, a preferred version, and any excluded
+ * versions consumable by a [ModuleDependency]
+ */
+sealed class ModuleVersionConstraint {
+  /** A version string, which may be a range if maven-style semantic versioning is used. */
+  abstract val requires: String?
+
+  /**
+   * An optional version [String], indicating a version which, if available, should be selected
+   * if multiple versions satisfy the [requires] constraint.  If [requires] is a single verions,
+   * then this preference is superfluous.
+   */
+  // TODO(cgruber) Determine what semantic there is for a conflict between prefers and excludes.
+  abstract val prefers: String?
+
+  /** A list of [String] versions which should be considered ineligible. */
+  abstract val rejects: List<String>
+
+  data class ModuleVersionConstraintV1_1(
+    override val requires: String? = null,
+    override val prefers: String? = null,
+    override val rejects: List<String> = listOf()
+  ) : ModuleVersionConstraint()
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
+++ b/src/test/java/com/squareup/tools/maven/resolution/BUILD.bazel
@@ -27,6 +27,46 @@ kt_jvm_library(
 )
 
 kt_jvm_test(
+    name = "GradleModelTest",
+    srcs = ["GradleModelTest.kt"],
+    friends = ["//src/main/java/com/squareup/tools/maven/resolution/gradle"],
+    test_class = "com.squareup.tools.maven.resolution.GradleModelTest",
+    deps = [
+        "//src/main/java/com/squareup/tools/maven/resolution/gradle",
+        "@maven//com/google/truth",
+        "@maven//junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "GradleModuleParsingTest",
+    size = "medium",
+    srcs = ["GradleModuleParsingTest.kt"],
+    data = glob(["data/*.module"]),
+    friends = ["//src/main/java/com/squareup/tools/maven/resolution/gradle"],
+    test_class = "com.squareup.tools.maven.resolution.GradleModuleParsingTest",
+    deps = [
+        "//src/main/java/com/squareup/tools/maven/resolution/gradle",
+        "@maven//com/google/truth",
+        "@maven//com/squareup/okio",
+        "@maven//junit",
+    ],
+)
+
+kt_jvm_test(
+    name = "GradleModuleResolutionTest",
+    srcs = ["GradleModuleResolutionTest.kt"],
+    friends = [":testlib"],
+    test_class = "com.squareup.tools.maven.resolution.GradleModuleResolutionTest",
+    deps = [
+        ":testlib",
+        "//src/main/java/com/squareup/tools/maven/resolution",
+        "@maven//com/google/truth",
+        "@maven//junit",
+    ],
+)
+
+kt_jvm_test(
     name = "MavenVersionTest",
     srcs = ["MavenVersionTest.kt"],
     friends = ["//src/main/java/com/squareup/tools/maven/resolution"],

--- a/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/FakeFetcher.kt
@@ -56,6 +56,7 @@ internal fun MutableMap<String, String>.fakeArtifact(
   suffix: String,
   pomContent: String,
   fileContent: String,
+  gradleModuleContent: String? = null,
   sourceContent: String? = null,
   realHash: Boolean = true,
   classifiedFiles: Map<String, Pair<String, String>> = mapOf() // classifier=(content=suffix)
@@ -74,6 +75,11 @@ internal fun MutableMap<String, String>.fakeArtifact(
     put("$dir/$filePrefix-sources.jar", sourceContent)
     put("$dir/$filePrefix-sources.jar.sha1", if (realHash) sourceContent.sha1() else "badhash")
     put("$dir/$filePrefix-sources.jar.md5", if (realHash) sourceContent.md5() else "badhash")
+  }
+  if (gradleModuleContent != null) {
+    put("$dir/$filePrefix.module", gradleModuleContent)
+    put("$dir/$filePrefix.module.sha1", if (realHash) gradleModuleContent.sha1() else "badhash")
+    put("$dir/$filePrefix.module.md5", if (realHash) gradleModuleContent.md5() else "badhash")
   }
   for ((classifier, value) in classifiedFiles) {
     val (content, suffix) = value // can't nest destructuring

--- a/src/test/java/com/squareup/tools/maven/resolution/GradleModelTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/GradleModelTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("ResolutionTest")
+package com.squareup.tools.maven.resolution
+
+import com.squareup.tools.maven.resolution.gradle.AvailableAt.AvailableAtV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleDependencyConstraint.ModuleDependencyConstraintV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleFile.ModuleFileV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleVariant.ModuleVariantV1_1
+import com.squareup.tools.maven.resolution.gradle.ModuleVersionConstraint.ModuleVersionConstraintV1_1
+import org.junit.Assert.assertThrows
+import org.junit.Test
+
+class GradleModelTest {
+
+  @Test fun testModuleVariantValidity() {
+    assertThrows(IllegalArgumentException::class.java) {
+      ModuleVariantV1_1(
+        name = "f",
+        availableAt = AvailableAtV1_1("foo", "bar", "baz"),
+        files = listOf(ModuleFileV1_1(url = "f", name = "f.txt", size = 5))
+      )
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      ModuleVariantV1_1(
+        name = "f",
+        availableAt = AvailableAtV1_1("foo", "bar", "baz"),
+        dependencyConstraints = listOf(
+          ModuleDependencyConstraintV1_1("foo", "bar", ModuleVersionConstraintV1_1("2.2"))
+        )
+      )
+    }
+    assertThrows(IllegalArgumentException::class.java) {
+      ModuleVariantV1_1(
+        name = "f",
+        availableAt = AvailableAtV1_1("foo", "bar", "baz"),
+        dependencyConstraints = listOf(
+          ModuleDependencyConstraintV1_1("foo", "bar", ModuleVersionConstraintV1_1("2.2"))
+        ),
+        files = listOf(ModuleFileV1_1(url = "f", name = "f.txt", size = 5))
+      )
+    }
+    // Should create fine
+    ModuleVariantV1_1(name = "f")
+    ModuleVariantV1_1(
+      name = "f",
+      files = listOf(ModuleFileV1_1(url = "f", name = "f.txt", size = 5))
+    )
+    ModuleVariantV1_1(
+      name = "f",
+      dependencyConstraints = listOf(
+        ModuleDependencyConstraintV1_1("foo", "bar", ModuleVersionConstraintV1_1("2.2"))
+      )
+    )
+    ModuleVariantV1_1(
+      name = "f",
+      dependencyConstraints = listOf(
+        ModuleDependencyConstraintV1_1("foo", "bar", ModuleVersionConstraintV1_1("2.2"))
+      ),
+      files = listOf(ModuleFileV1_1(url = "f", name = "f.txt", size = 5))
+    )
+  }
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/GradleModuleParsingTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/GradleModuleParsingTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("ResolutionTest")
+package com.squareup.tools.maven.resolution
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.tools.maven.resolution.gradle.GradleModuleParser
+import java.nio.file.Paths
+import org.junit.Test
+
+class GradleModuleParsingTest {
+  private val runfiles = Paths.get(System.getenv("JAVA_RUNFILES")!!)
+  private val workspace = runfiles.resolve(Paths.get(System.getenv("TEST_WORKSPACE")!!))
+  private val here = workspace.resolve(Paths.get(System.getenv("TEST_BINARY")!!).parent)
+
+  @Test fun parseOkio260() {
+    val parser = GradleModuleParser()
+    val model = parser.parse(here.resolve("data/okio-2.6.0.module"))
+    requireNotNull(model)
+    assertThat(model.formatVersion).isEqualTo("1.1")
+  }
+
+  @Test fun parseV1_0() {
+    val parser = GradleModuleParser()
+    val model = parser.parse(here.resolve("data/gradle-module-spec-1.0-example.module"))
+    requireNotNull(model)
+    assertThat(model.formatVersion).isEqualTo("1.0")
+  }
+
+  @Test fun parseV1_1() {
+    val parser = GradleModuleParser()
+    val model = parser.parse(here.resolve("data/gradle-module-spec-1.1-example.module"))
+    requireNotNull(model)
+    assertThat(model.formatVersion).isEqualTo("1.1")
+  }
+
+  @Test fun parseExtraAttributes() {
+    val parser = GradleModuleParser()
+    val model = parser.parse(here.resolve("data/extra-attributes.module"))
+    requireNotNull(model)
+    assertThat(model.formatVersion).isEqualTo("1.1")
+    assertThat(model.variants[0].attributes["org.gradle.usage"]).isEqualTo("java-api")
+    assertThat(model.variants[0].attributes["foo.bar.baz"]).isEqualTo("blah")
+  }
+
+  @Test fun parseExampleFromGradleCodebase() {
+    val parser = GradleModuleParser()
+    val model = parser.parse(here.resolve("data/gradle-example-java-library.module"))
+    requireNotNull(model)
+    assertThat(model.formatVersion).isEqualTo("1.0")
+    assertThat(model.variants[0].attributes["org.gradle.usage"]).isEqualTo("java-runtime")
+  }
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/GradleModuleResolutionTest.kt
+++ b/src/test/java/com/squareup/tools/maven/resolution/GradleModuleResolutionTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:JvmName("ResolutionTest")
+package com.squareup.tools.maven.resolution
+
+import com.google.common.truth.Truth.assertThat
+import com.squareup.tools.maven.resolution.FetchStatus.RepositoryFetchStatus.SUCCESSFUL
+import java.nio.file.Files
+import org.apache.maven.model.Repository
+import org.apache.maven.model.RepositoryPolicy
+import org.junit.After
+import org.junit.Test
+
+class GradleModuleResolutionTest {
+  private val cacheDir = Files.createTempDirectory("resolution-test-")
+  private val repoId = "fake-repo"
+  private val repoUrl = "fake://repo"
+  private val repositories = listOf(Repository().apply {
+    id = repoId
+    releases = RepositoryPolicy().apply { enabled = "true" }
+    url = repoUrl
+  })
+  private val fakeFetcher = FakeFetcher(
+      cacheDir = cacheDir,
+      repositoriesContent = mapOf(repoId to mutableMapOf<String, String>()
+          .fakeArtifact(
+              repoUrl = "fake://repo",
+              coordinate = "foo.bar:bar:1",
+              suffix = "txt",
+              pomContent = """<?xml version="1.0" encoding="UTF-8"?>
+                  <project><modelVersion>4.0.0</modelVersion>
+                    <groupId>foo.bar</groupId>
+                    <artifactId>bar</artifactId>
+                    <version>1</version>
+                    <packaging>txt</packaging> 
+                  </project>
+                  """.trimIndent(),
+              gradleModuleContent = """
+                {
+                    "formatVersion": "1.1",
+                    "component": {
+                        "group": "foo.bar",
+                        "module": "bar",
+                        "version": "1"
+                    },
+                    "createdBy": {
+                        "fake": {
+                            "version": "1"
+                        }
+                    },
+                    "variants": [
+                        {
+                            "name": "api",
+                            "attributes": {
+                                "org.gradle.usage": "java-api",
+                                "org.gradle.category": "library",
+                                "org.gradle.libraryelements": "jar"
+                            },
+                            "files": [
+                                { 
+                                    "name": "mylib-api.jar", 
+                                    "url": "mylib-api-1.2.jar",
+                                    "size": "1453",
+                                    "sha1": "abc12345",
+                                    "md5": "abc12345"
+                                }
+                            ],
+                            "dependencies": [
+                                { 
+                                    "group": "some.group", 
+                                    "module": "other-lib", 
+                                    "version": { "requires": "3.4" },
+                                    "excludes": [
+                                        { "group": "*", "module": "excluded-lib" }
+                                    ],
+                                    "attributes": {
+                                       "buildType": "debug"
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "runtime",
+                            "attributes": {
+                                "org.gradle.usage": "java-runtime",
+                                "org.gradle.category": "library",
+                                "org.gradle.libraryelements": "jar"
+                            },
+                            "files": [
+                                { 
+                                    "name": "mylib.jar", 
+                                    "url": "mylib-1.2.jar",
+                                    "size": "4561",
+                                    "sha1": "abc12345",
+                                    "md5": "abc12345"
+                                }
+                            ],
+                            "dependencies": [
+                                { 
+                                    "group": "some.group", 
+                                    "module": "other-lib", 
+                                    "version": { "requires": "[3.0, 4.0)", "prefers": "3.4", "rejects": ["3.4.1"] } 
+                                }
+                            ],
+                            "dependencyConstraints": [
+                                { 
+                                    "group": "some.group", 
+                                    "module": "other-lib-2", 
+                                    "version": { "requires": "1.0" } 
+                                }
+                            ]
+                        }
+                    ]
+                }
+              """.trimIndent(),
+              fileContent = "bar\n",
+              sourceContent = "sources",
+              classifiedFiles = mapOf("extra" to ("extrastuff" to "bargle"))
+          )
+        .fakeArtifact(
+          repoUrl = "fake://repo",
+          coordinate = "foo.bar:baz:2",
+          suffix = "txt",
+          pomContent = """<?xml version="1.0" encoding="UTF-8"?>
+                  <project><modelVersion>4.0.0</modelVersion>
+                    <groupId>foo.bar</groupId>
+                    <artifactId>baz</artifactId>
+                    <version>2</version>
+                    <packaging>txt</packaging> 
+                  </project>
+                  """.trimIndent(),
+          fileContent = "baz\n"
+        )
+      )
+  )
+
+  private val resolver = ArtifactResolver(
+    cacheDir = cacheDir,
+    fetcher = fakeFetcher,
+    repositories = repositories
+  )
+
+  @After fun tearDown() {
+    cacheDir.toFile().deleteRecursively()
+    check(!cacheDir.exists) { "Failed to tear down and delete temp directory." }
+  }
+
+  @Test fun testResolution() {
+    val artifact = resolver.artifactFor("foo.bar:bar:1")
+    assertThat(!artifact.pom.localFile.exists).isTrue()
+    assertThat(!artifact.gradleModule.localFile.exists).isTrue()
+
+    val result = resolver.resolve(artifact)
+    assertThat(result.status).isInstanceOf(SUCCESSFUL::class.java)
+    val resolved = result.artifact!!
+    assertThat(resolved).isNotNull()
+    assertThat(resolved!!.pom.localFile.exists).isTrue()
+    assertThat(resolved.pom.localFile.readText()).contains("<groupId>foo.bar</groupId>")
+    assertThat(resolved.pom.localFile.readText()).contains("<artifactId>bar</artifactId>")
+    assertThat(resolved.pom.localFile.readText()).contains("<version>1</version>")
+    assertThat(resolved.gradleModule.localFile.readText()).contains("\"formatVersion\": \"1.1\"")
+
+    assertThat(resolved.model)
+  }
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/data/extra-attributes.module
+++ b/src/test/java/com/squareup/tools/maven/resolution/data/extra-attributes.module
@@ -1,0 +1,52 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "my.group",
+    "module": "mylib",
+    "version": "1.2"
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "4.3",
+      "buildId": "abc123"
+    }
+  },
+  "variants": [
+    {
+      "name": "api",
+      "attributes": {
+        "org.gradle.usage": "java-api",
+        "org.gradle.category": "library",
+        "org.gradle.libraryelements": "jar",
+        "foo.bar.baz": "blah"
+      },
+      "files": [
+        {
+          "name": "mylib-api.jar",
+          "url": "mylib-api-1.2.jar",
+          "size": "1453",
+          "sha1": "abc12345",
+          "md5": "abc12345"
+        }
+      ],
+      "dependencies": [
+        {
+          "group": "some.group",
+          "module": "other-lib",
+          "version": {
+            "requires": "3.4"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "excluded-lib"
+            }
+          ],
+          "attributes": {
+            "buildType": "debug"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/data/gradle-example-java-library.module
+++ b/src/test/java/com/squareup/tools/maven/resolution/data/gradle-example-java-library.module
@@ -1,0 +1,185 @@
+{
+  "formatVersion": "1.0",
+  "component": {
+    "group": "org.gradle.test",
+    "module": "publishTest",
+    "version": "1.9",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "4.5-20171204230000+0000",
+      "buildId": "mmkppe3smvbgbhp5yeotxkaweq"
+    }
+  },
+  "variants": [
+    {
+      "name": "runtime",
+      "attributes": {
+        "org.gradle.usage": "java-runtime"
+      },
+      "dependencies": [
+        {
+          "group": "commons-collections",
+          "module": "commons-collections",
+          "version": {
+            "prefers": "3.2.2"
+          }
+        },
+        {
+          "group": "org.springframework",
+          "module": "spring-core",
+          "version": {
+            "prefers": "2.5.6"
+          },
+          "excludes": [
+            {
+              "group": "commons-logging",
+              "module": "commons-logging"
+            }
+          ]
+        },
+        {
+          "group": "commons-beanutils",
+          "module": "commons-beanutils",
+          "version": {
+            "prefers": "1.8.3"
+          },
+          "excludes": [
+            {
+              "group": "commons-logging",
+              "module": "*"
+            }
+          ]
+        },
+        {
+          "group": "commons-dbcp",
+          "module": "commons-dbcp",
+          "version": {
+            "prefers": "1.4"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "*"
+            }
+          ]
+        },
+        {
+          "group": "org.apache.camel",
+          "module": "camel-jackson",
+          "version": {
+            "prefers": "2.15.3"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "camel-core"
+            }
+          ]
+        },
+        {
+          "group": "commons-io",
+          "module": "commons-io",
+          "version": {
+            "prefers": "1.4"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "publishTest-1.9.jar",
+          "url": "publishTest-1.9.jar",
+          "size": 261,
+          "sha1": "7577e284a8b6daf5cb2fe0d826343f22fadb8ad0",
+          "md5": "7233c4d2f6a17fd35a2def674868828b"
+        }
+      ]
+    },
+    {
+      "name": "api",
+      "attributes": {
+        "org.gradle.usage": "java-api"
+      },
+      "dependencies": [
+        {
+          "group": "commons-io",
+          "module": "commons-io",
+          "version": {
+            "prefers": "1.4"
+          }
+        },
+        {
+          "group": "commons-collections",
+          "module": "commons-collections",
+          "version": {
+            "prefers": "3.2.2"
+          }
+        },
+        {
+          "group": "org.springframework",
+          "module": "spring-core",
+          "version": {
+            "prefers": "2.5.6"
+          },
+          "excludes": [
+            {
+              "group": "commons-logging",
+              "module": "commons-logging"
+            }
+          ]
+        },
+        {
+          "group": "commons-beanutils",
+          "module": "commons-beanutils",
+          "version": {
+            "prefers": "1.8.3"
+          },
+          "excludes": [
+            {
+              "group": "commons-logging",
+              "module": "*"
+            }
+          ]
+        },
+        {
+          "group": "commons-dbcp",
+          "module": "commons-dbcp",
+          "version": {
+            "prefers": "1.4"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "*"
+            }
+          ]
+        },
+        {
+          "group": "org.apache.camel",
+          "module": "camel-jackson",
+          "version": {
+            "prefers": "2.15.3"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "camel-core"
+            }
+          ]
+        }
+      ],
+      "files": [
+        {
+          "name": "publishTest-1.9.jar",
+          "url": "publishTest-1.9.jar",
+          "size": 261,
+          "sha1": "7577e284a8b6daf5cb2fe0d826343f22fadb8ad0",
+          "md5": "7233c4d2f6a17fd35a2def674868828b"
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/data/gradle-module-spec-1.0-example.module
+++ b/src/test/java/com/squareup/tools/maven/resolution/data/gradle-module-spec-1.0-example.module
@@ -1,0 +1,90 @@
+{
+  "formatVersion": "1.0",
+  "component": {
+    "group": "my.group",
+    "module": "mylib",
+    "version": "1.2"
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "4.3",
+      "buildId": "abc123"
+    }
+  },
+  "variants": [
+    {
+      "name": "api",
+      "attributes": {
+        "org.gradle.usage": "java-api",
+        "org.gradle.category": "library",
+        "org.gradle.libraryelements": "jar"
+      },
+      "files": [
+        {
+          "name": "mylib-api.jar",
+          "url": "mylib-api-1.2.jar",
+          "size": "1453",
+          "sha1": "abc12345",
+          "md5": "abc12345"
+        }
+      ],
+      "dependencies": [
+        {
+          "group": "some.group",
+          "module": "other-lib",
+          "version": {
+            "requires": "3.4"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "excluded-lib"
+            }
+          ],
+          "attributes": {
+            "buildType": "debug"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "attributes": {
+        "org.gradle.usage": "java-runtime",
+        "org.gradle.category": "library",
+        "org.gradle.libraryelements": "jar"
+      },
+      "files": [
+        {
+          "name": "mylib.jar",
+          "url": "mylib-1.2.jar",
+          "size": "4561",
+          "sha1": "abc12345",
+          "md5": "abc12345"
+        }
+      ],
+      "dependencies": [
+        {
+          "group": "some.group",
+          "module": "other-lib",
+          "version": {
+            "requires": "[3.0, 4.0)",
+            "prefers": "3.4",
+            "rejects": [
+              "3.4.1"
+            ]
+          }
+        }
+      ],
+      "dependencyConstraints": [
+        {
+          "group": "some.group",
+          "module": "other-lib-2",
+          "version": {
+            "requires": "1.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/data/gradle-module-spec-1.1-example.module
+++ b/src/test/java/com/squareup/tools/maven/resolution/data/gradle-module-spec-1.1-example.module
@@ -1,0 +1,98 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "my.group",
+    "module": "mylib",
+    "version": "1.2"
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "4.3",
+      "buildId": "abc123"
+    }
+  },
+  "variants": [
+    {
+      "name": "api",
+      "attributes": {
+        "org.gradle.usage": "java-api",
+        "org.gradle.category": "library",
+        "org.gradle.libraryelements": "jar"
+      },
+      "files": [
+        {
+          "name": "mylib-api.jar",
+          "url": "mylib-api-1.2.jar",
+          "size": "1453",
+          "sha1": "abc12345",
+          "md5": "abc12345"
+        }
+      ],
+      "dependencies": [
+        {
+          "group": "some.group",
+          "module": "other-lib",
+          "version": {
+            "requires": "3.4"
+          },
+          "excludes": [
+            {
+              "group": "*",
+              "module": "excluded-lib"
+            }
+          ],
+          "attributes": {
+            "buildType": "debug"
+          }
+        }
+      ]
+    },
+    {
+      "name": "runtime",
+      "attributes": {
+        "org.gradle.usage": "java-runtime",
+        "org.gradle.category": "library",
+        "org.gradle.libraryelements": "jar"
+      },
+      "files": [
+        {
+          "name": "mylib.jar",
+          "url": "mylib-1.2.jar",
+          "size": "4561",
+          "sha1": "abc12345",
+          "md5": "abc12345"
+        }
+      ],
+      "dependencies": [
+        {
+          "group": "some.group",
+          "module": "other-lib",
+          "version": {
+            "requires": "[3.0, 4.0)",
+            "prefers": "3.4",
+            "rejects": [
+              "3.4.1"
+            ]
+          },
+          "thirdPartyCompatibility": {
+            "artifactSelector":{
+              "name": "alldeps",
+              "type": "jar",
+              "extension": "jar",
+              "classifier": "alldeps"
+            }
+          }
+        }
+      ],
+      "dependencyConstraints": [
+        {
+          "group": "some.group",
+          "module": "other-lib-2",
+          "version": {
+            "requires": "1.0"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/data/okio-2.6.0.module
+++ b/src/test/java/com/squareup/tools/maven/resolution/data/okio-2.6.0.module
@@ -1,0 +1,103 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "url": "../../okio-multiplatform/2.6.0/okio-multiplatform-2.6.0.module",
+    "group": "com.squareup.okio",
+    "module": "okio-multiplatform",
+    "version": "2.6.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "6.2.1",
+      "buildId": "uq4xtxw34nhrli5ohrpwvbosta"
+    }
+  },
+  "variants": [
+    {
+      "name": "jvm-api",
+      "attributes": {
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "jvm"
+      },
+      "dependencies": [
+        {
+          "group": "org.jetbrains.kotlin",
+          "module": "kotlin-stdlib",
+          "version": {
+            "requires": "1.3.70"
+          }
+        },
+        {
+          "group": "org.jetbrains.kotlin",
+          "module": "kotlin-stdlib-common",
+          "version": {
+            "requires": "1.3.70"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "okio-jvm-2.6.0.jar",
+          "url": "okio-2.6.0.jar",
+          "size": 243330,
+          "sha512": "9d592ad17e09bb8cdd6490d42c8274ceddbaf6c70e0704dde0745501fcc5f5c88f0a7825257b6fab1221e6dcb8e149815750a5f71c81eef67a6df4aebda1ca40",
+          "sha256": "4d84ef686277b58eb05691ac19cd3befa3429a27274982ee65ea0f07044bcc00",
+          "sha1": "0f06923d428f3c8e6f571043ec29a45d0cd9d2bf",
+          "md5": "0e259823ad4d04c10ccd730c712bbb8d"
+        }
+      ]
+    },
+    {
+      "name": "jvm-runtime",
+      "attributes": {
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "jvm"
+      },
+      "dependencies": [
+        {
+          "group": "org.jetbrains.kotlin",
+          "module": "kotlin-stdlib",
+          "version": {
+            "requires": "1.3.70"
+          }
+        },
+        {
+          "group": "org.jetbrains.kotlin",
+          "module": "kotlin-stdlib-common",
+          "version": {
+            "requires": "1.3.70"
+          }
+        }
+      ],
+      "files": [
+        {
+          "name": "okio-jvm-2.6.0.jar",
+          "url": "okio-2.6.0.jar",
+          "size": 243330,
+          "sha512": "9d592ad17e09bb8cdd6490d42c8274ceddbaf6c70e0704dde0745501fcc5f5c88f0a7825257b6fab1221e6dcb8e149815750a5f71c81eef67a6df4aebda1ca40",
+          "sha256": "4d84ef686277b58eb05691ac19cd3befa3429a27274982ee65ea0f07044bcc00",
+          "sha1": "0f06923d428f3c8e6f571043ec29a45d0cd9d2bf",
+          "md5": "0e259823ad4d04c10ccd730c712bbb8d"
+        }
+      ]
+    },
+    {
+      "name": "metadata-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "common"
+      },
+      "available-at": {
+        "url": "../../okio-metadata/2.6.0/okio-metadata-2.6.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-metadata",
+        "version": "2.6.0"
+      }
+    }
+  ]
+}

--- a/src/test/java/com/squareup/tools/maven/resolution/data/okio-multiplatform-2.6.0.module
+++ b/src/test/java/com/squareup/tools/maven/resolution/data/okio-multiplatform-2.6.0.module
@@ -1,0 +1,142 @@
+{
+  "formatVersion": "1.1",
+  "component": {
+    "group": "com.squareup.okio",
+    "module": "okio-multiplatform",
+    "version": "2.7.0",
+    "attributes": {
+      "org.gradle.status": "release"
+    }
+  },
+  "createdBy": {
+    "gradle": {
+      "version": "6.4.1",
+      "buildId": "rr33lv7ztfbvzhu54qsrpixwou"
+    }
+  },
+  "variants": [
+    {
+      "name": "iosArm64-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.native.target": "ios_arm64",
+        "org.jetbrains.kotlin.platform.type": "native"
+      },
+      "available-at": {
+        "url": "../../okio-iosarm64/2.7.0/okio-iosarm64-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-iosarm64",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "iosX64-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.native.target": "ios_x64",
+        "org.jetbrains.kotlin.platform.type": "native"
+      },
+      "available-at": {
+        "url": "../../okio-iosx64/2.7.0/okio-iosx64-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-iosx64",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "js-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "js"
+      },
+      "available-at": {
+        "url": "../../okio-js/2.7.0/okio-js-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-js",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "js-runtime",
+      "attributes": {
+        "org.gradle.usage": "kotlin-runtime",
+        "org.jetbrains.kotlin.platform.type": "js"
+      },
+      "available-at": {
+        "url": "../../okio-js/2.7.0/okio-js-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-js",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "jvm-api",
+      "attributes": {
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-api",
+        "org.jetbrains.kotlin.platform.type": "jvm"
+      },
+      "available-at": {
+        "url": "../../okio/2.7.0/okio-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "jvm-runtime",
+      "attributes": {
+        "org.gradle.libraryelements": "jar",
+        "org.gradle.usage": "java-runtime",
+        "org.jetbrains.kotlin.platform.type": "jvm"
+      },
+      "available-at": {
+        "url": "../../okio/2.7.0/okio-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "linuxX64-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.native.target": "linux_x64",
+        "org.jetbrains.kotlin.platform.type": "native"
+      },
+      "available-at": {
+        "url": "../../okio-linuxx64/2.7.0/okio-linuxx64-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-linuxx64",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "macosX64-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.native.target": "macos_x64",
+        "org.jetbrains.kotlin.platform.type": "native"
+      },
+      "available-at": {
+        "url": "../../okio-macosx64/2.7.0/okio-macosx64-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-macosx64",
+        "version": "2.7.0"
+      }
+    },
+    {
+      "name": "metadata-api",
+      "attributes": {
+        "org.gradle.usage": "kotlin-api",
+        "org.jetbrains.kotlin.platform.type": "common"
+      },
+      "available-at": {
+        "url": "../../okio-metadata/2.7.0/okio-metadata-2.7.0.module",
+        "group": "com.squareup.okio",
+        "module": "okio-metadata",
+        "version": "2.7.0"
+      }
+    }
+  ]
+}

--- a/versions.bzl
+++ b/versions.bzl
@@ -64,7 +64,10 @@ DIRECT_ARTIFACTS = {
         "testonly": True,
         "exclude": ["com.google.guava:failureaccess", "com.google.guava:listenablefuture"],
     },
-    "com.squareup.okhttp3:okhttp:4.4.1": {"insecure": True},
+    "com.squareup.okhttp3:okhttp:4.7.2": {"insecure": True},
+    "com.squareup.okio:okio:2.6.0": {"insecure": True},
+    "com.squareup.moshi:moshi:1.9.3": {"insecure": True},
+    "com.squareup.moshi:moshi-kotlin:1.9.3": {"insecure": True},
     "org.apache.maven:maven-artifact:%s" % MAVEN_LIBRARY_VERSION: {"insecure": True},
     "org.apache.maven:maven-builder-support:%s" % MAVEN_LIBRARY_VERSION: {"insecure": True},
     "org.apache.maven:maven-model:%s" % MAVEN_LIBRARY_VERSION: {"insecure": True},
@@ -82,7 +85,6 @@ TRANSITIVE_ARTIFACTS = [
     "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
     "com.google.j2objc:j2objc-annotations:1.1",
     "com.googlecode.java-diff-utils:diffutils:1.3.0",
-    "com.squareup.okio:okio:2.4.3",
     "org.apache.commons:commons-lang3:3.8.1",
     "org.checkerframework:checker-compat-qual:2.5.5",
     "org.checkerframework:checker-qual:2.5.2",
@@ -92,6 +94,7 @@ TRANSITIVE_ARTIFACTS = [
     "org.hamcrest:hamcrest-core:1.3",
     "org.jetbrains.kotlin:kotlin-stdlib-common:%s" % KOTLIN_VERSION,
     "org.jetbrains.kotlin:kotlin-stdlib:%s" % KOTLIN_VERSION,
+    "org.jetbrains.kotlin:kotlin-reflect:%s" % KOTLIN_VERSION,
     "org.jetbrains:annotations:13.0",
 ]
 


### PR DESCRIPTION
Gradle publishes additional metadata in a file suffixed by .module, which supplants the maven pom during gradle builds. This is also the mechanism by which certain other features, such as kotlin multiplatform artifact referencing is done. This commit adds support for parsing those files, with some buffering against evolution of the data file format (versioned data classes, and a place to add selection by formatVersion once incompatible versions of the spec come out.  For the moment, the 1.1 spec is a strict superset, so 1.0 files are parseable by the same parser, into the same data objects. The model objects are kotlin data classes for the implementations, easily targeted by moshi for the parse outcomes. The parser is a moshi kotlin configuration.

No semantics are assumed in this model - no further resolution, or following available-at references. That is the responsibility of clients, to interpret according to gradle's specified semantics.