### PR TITLE
Make ArtifactResolver somewhat compatible with Java.

### DIFF
--- a/src/main/java/com/squareup/tools/maven/resolution/ArtifactResolver.kt
+++ b/src/main/java/com/squareup/tools/maven/resolution/ArtifactResolver.kt
@@ -90,7 +90,7 @@ import org.apache.maven.model.validation.DefaultModelValidator
  * local repository location). This can be configured for each [ArtifactResolver] instance via the
  * [cacheDir] property.
  */
-class ArtifactResolver(
+class ArtifactResolver @JvmOverloads constructor(
   suppressAddRepositoryWarnings: Boolean = false,
   private val strictHashValidation: Boolean = false,
   /** Should the resolver fetch the gradle module when fetching the pom file? */


### PR DESCRIPTION
I would highly appreciate if we could give the ArtifactResolver a java-compatible constructor. Currenly there is no way to get the SimpleHttpClient/Resolver since they are internal, which results in java users using very ugly reflection or creating a kotlin wrapper around it and including that. This would allow java users to take more advantage of the default values and then I can drop a bridge library and save on code. I haven't tested this, nor done anything with it. I don't use Bazel, plugin is not updated for newest IntelliJ and the weird directories it links don't work with WSL and IntelliJ interfacing into it.